### PR TITLE
Remove the web-console gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,9 +39,6 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'
 
-  # Access an IRB console on exception pages or by using <%= console %> in views
-  gem 'web-console', '~> 2.0'
-
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,8 +37,6 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     arel (6.0.0)
-    binding_of_caller (0.7.2)
-      debug_inspector (>= 0.0.1)
     builder (3.2.2)
     byebug (4.0.5)
       columnize (= 0.9.0)
@@ -50,7 +48,6 @@ GEM
       execjs
     coffee-script-source (1.9.1)
     columnize (0.9.0)
-    debug_inspector (0.0.2)
     erubis (2.7.0)
     execjs (2.5.2)
     globalid (0.3.5)
@@ -142,11 +139,6 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    web-console (2.1.2)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
 
 PLATFORMS
   ruby
@@ -165,4 +157,6 @@ DEPENDENCIES
   spring
   turbolinks
   uglifier (>= 1.3.0)
-  web-console (~> 2.0)
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
See the "Rails Webconsole DNS Rebinding issue" email thread for details, also:

https://benmmurphy.github.io/blog/2016/07/11/rails-webconsole-dns-rebinding/

Please update [this spreadsheet](https://docs.google.com/spreadsheets/d/1omuPIH1Nuzmch1WIjVj_VdnB3ERFJxaxe6915sZHAOY/edit) when this has been merged. Thank you! :smile: 

@raulb @heroku/prodsec 